### PR TITLE
Fix transparent dropdowns

### DIFF
--- a/themes/color-theme.json
+++ b/themes/color-theme.json
@@ -2077,7 +2077,7 @@
     "checkbox.background": "#ffffff14",
     "checkbox.foreground": "#dbdbdb",
     "checkbox.border": "#00000000",
-    "dropdown.background": "#ffffff14",
+    "dropdown.background": "#281430",
     "dropdown.foreground": "#dbdbdb",
     "dropdown.border": "#00000000",
     "minimapGutter.addedBackground": "#fede5d",


### PR DESCRIPTION
While `"#ffffff14"` softens the `"input.background"` elements, it breaks readability on the `"dropdown.background"`.
Sampling colors off a screenshot puts the resulting color at `#281430`. I haven't found any other elements breaking on transparency, so sorry for the single line PR.
Before:
![image](https://user-images.githubusercontent.com/14993038/173845121-20f9f095-a049-4187-a773-cddb1d47a629.png)

Fixed:
![image](https://user-images.githubusercontent.com/14993038/173845331-998eba6c-774c-422d-b989-c91bb0f8aa2c.png)
